### PR TITLE
chore(agents): update model from claude-opus-4-5 to claude-opus-4-6

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -37,4 +37,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENCODE_PERMISSION: '{"bash": "deny"}'
         with:
-          model: opencode/claude-opus-4-5
+          model: opencode/claude-opus-4-6


### PR DESCRIPTION
## Summary

- Updates `opencode/claude-opus-4-5` to `opencode/claude-opus-4-6` in the OpenCode workflow
- Keeps the OpenCode agent model in sync with the latest available version